### PR TITLE
[local-namespace] Added a localNamespace option for namespacing localhost

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -37,14 +37,14 @@ var utils = {
 
         var port   = options.get("port");
         var urls   = {};
+        var localhost = options.get("localNamespace") || "localhost";
 
         if (options.get("online") === false) {
-            urls.local = utils.getUrl(scheme + "://localhost:" + port, options);
+            urls.local = utils.getUrl(scheme + "://" + localhost + ":" + port, options);
             return Immutable.fromJS(urls);
         }
 
         var external  = utils.xip(utils.getHostIp(options, devIp), options);
-        var localhost = "localhost";
 
         if (options.get("xip")) {
             localhost = "127.0.0.1";

--- a/test/specs/utils/utils.setUrlOptions.js
+++ b/test/specs/utils/utils.setUrlOptions.js
@@ -73,4 +73,43 @@ describe("Utils: creating URLs", function () {
             local: "http://localhost:3000"
         });
     });
+    it("should return the external/local namespace", function () {
+        var opts = merge({
+            port: 3000,
+            server: true,
+            scheme: "http",
+            online: true,
+            localNamespace: "local.dev"
+        });
+        assert.deepEqual(utils.getUrlOptions(opts).toJS(), {
+            local: "http://local.dev:3000",
+            external: "http://" + external + ":3000"
+        });
+    });
+    it("should return the URLs when local namespace, OFFLINE, & XIP set", function () {
+        var opts = merge({
+            port: 3000,
+            server: true,
+            scheme: "http",
+            online: false,
+            xip: true,
+            localNamespace: "local.dev"
+        });
+        assert.deepEqual(utils.getUrlOptions(opts).toJS(), {
+            local: "http://local.dev:3000"
+        });
+    });
+    it("should return the external/local namespace with XIP", function () {
+        var opts = merge({
+            port: 3000,
+            server: true,
+            scheme: "https",
+            online: true,
+            xip: true,
+            localNamespace: "local.dev"
+        });
+        var out = utils.getUrlOptions(opts);
+        assert.equal(out.get("local"), "https://127.0.0.1.xip.io:3000");
+        assert.equal(out.get("external"), "https://" + external + ".xip.io:3000");
+    });
 });


### PR DESCRIPTION
Added a `localNamespace` option for namespacing to something other than localhost. Defaults to localhost if not set.

This solves the issue of not being able to set a localhost proxy when using the server option. By setting a `localNamespace` option the user has the option to hit something other than `localhost`, for example: `local.dev`.

Added additional tests in `utils.setUrlOptions.js` to confirm functionality. More tests are probably still needed to ensure compatibility with other parts of the system.
